### PR TITLE
Make this plugin work for Hyper v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 exports.decorateConfig = (config) => {
   config.termCSS = `
     ${config.termCSS || ''}
-    x-screen x-row {
+    x-screen x-row,
+    .xterm-rows > div {
       font-variant-ligatures: initial;
     }
   `


### PR DESCRIPTION
v2 of Hyper uses `xterm` (instead of the previous `hterm`) as terminal emulation library. Both use different tags + classNames that contain the actual terminal row content.

This change should make this plugin work for both v1 (using `x-screen x-row` custom tags) and v2 (using `.xterm-rows > div` classNamed tag's children (which are the appropriate alternative to the former implementation)).

NOTE: There will still be a warning, that this plugin uses deprecated stylings (`x-screen x-row`) on v2.